### PR TITLE
Initialize flipkart_etl project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,81 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+venv/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Environments
+.env
+.env.*
+
+# VS Code
+.vscode/
+
+# macOS
+.DS_Store
+
+# Windows
+Thumbs.db
+
+# Temporary files
+*~
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # Flipkart
-Repository for all scripts related to Flipkart data processing, scraping, and analysis.
+
+Collection of scripts and utilities related to Flipkart data processing, scraping, and analysis. This repository may host multiple subprojects. Current subprojects include:
+
+- **flipkart_etl** – cleans Flipkart Excel exports and uploads them to PostgreSQL.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Review each subproject's README for usage instructions.
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/flipkart_etl/README.md
+++ b/flipkart_etl/README.md
@@ -1,0 +1,28 @@
+# Flipkart ETL
+
+This module provides a command-line interface to clean Flipkart Excel data and upload the results to a PostgreSQL database.
+
+## Requirements
+Install dependencies using:
+
+```bash
+pip install -r ../../requirements.txt
+```
+
+## Environment Variables
+Set the following environment variables to configure the database connection and table name:
+
+- `DB_HOST` (default: `localhost`)
+- `DB_NAME` (default: `Shakedeal`)
+- `DB_USER` (default: `postgres`)
+- `DB_PASS` (default: `2705`)
+- `TABLE_NAME` (default: `flipkart_scrap`)
+
+## Usage
+Run the ETL from the project root with Python's `-m` flag:
+
+```bash
+python -m flipkart_etl path/to/file.xlsx --sheet Sheet1
+```
+
+The script will clean the data, add an `insertion_date` column, and append the records to the configured PostgreSQL table.

--- a/flipkart_etl/__init__.py
+++ b/flipkart_etl/__init__.py
@@ -1,0 +1,3 @@
+"""Flipkart ETL package."""
+
+__all__ = ["etl"]

--- a/flipkart_etl/__main__.py
+++ b/flipkart_etl/__main__.py
@@ -1,0 +1,4 @@
+from .etl import main
+
+if __name__ == "__main__":
+    main()

--- a/flipkart_etl/etl.py
+++ b/flipkart_etl/etl.py
@@ -1,0 +1,106 @@
+import os
+import pandas as pd
+import re
+from sqlalchemy import create_engine
+from datetime import datetime
+import argparse
+
+# === Database connection details via environment variables ===
+DB_HOST = os.environ.get("DB_HOST", "localhost")
+DB_NAME = os.environ.get("DB_NAME", "Shakedeal")
+DB_USER = os.environ.get("DB_USER", "postgres")
+DB_PASS = os.environ.get("DB_PASS", "2705")
+TABLE_NAME = os.environ.get("TABLE_NAME", "flipkart_scrap")
+
+# === Column renaming and dropping dictionaries ===
+RENAME_DICT = {
+    "TextHighlight": "Title",
+    "TextHighlight 2": "SKU",
+    "TextHighlight 3": "Category",
+    "styles__SellingPriceWrapper-sc-1n6ywsa-2": "Listing Price",
+    "styles__TbodyCell-dsgsck-4": "Benchmark Price",
+    "styles__FinalPriceWrapper-sc-dk1mu2-0": "Final Price",
+    "styles__RightAlignWrapper-sc-g11inc-0": "MRP",
+    "styles__FlexRow-sc-itsxp5-4": "Stock",
+    "styles__DoHWrapper-sc-itsxp5-6": "DOH",
+    "styles__TbodyCell-dsgsck-4 2": "Fulfillment Type",
+    "styles__RightAlignWrapper-sc-g11inc-0 2": "SLA",
+    "styles__StatusValue-y9chu4-1": "LQS",
+    "styles__ClickableContainer-sc-16isc7k-2 href": "Listing Link",
+    "styles__ReturnsCellContainer-sc-890y2z-17": "Returns"
+}
+
+DROP_COLUMNS = [
+    "styles__ProductIcon-sc-p666j7-4 src",
+    "styles__ReturnsContainer-sc-1qs5x67-4",
+    "styles__RedText-sc-1qs5x67-5",
+    "styles__ReturnsContainer-sc-1qs5x67-4 href",
+    "styles__TbodyCell-dsgsck-4 3"
+]
+
+def extract_fsn(url: str):
+    """Parse the FSN (Flipkart Serial Number) from a URL."""
+    match = re.search(r'[\?&]pid=([A-Z0-9]+)', str(url))
+    return match.group(1) if match else None
+
+def clean_data(df: pd.DataFrame) -> pd.DataFrame:
+    """Clean and format the Flipkart scrap data."""
+    df = df.copy()
+    df.rename(columns=RENAME_DICT, inplace=True)
+    df.drop(columns=DROP_COLUMNS, inplace=True, errors="ignore")
+
+    text_columns = ["Title", "SKU", "Category", "Fulfillment Type", "LQS"]
+    for col in text_columns:
+        if col in df.columns:
+            df[col] = df[col].astype(str).str.strip()
+
+    num_columns = ["Listing Price", "Benchmark Price", "Final Price", "MRP", "Stock", "Returns"]
+    for col in num_columns:
+        if col in df.columns:
+            df[col] = df[col].astype(str).str.replace(r"[^\d.]", "", regex=True)
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+
+    if "Stock" in df.columns:
+        df["Stock"] = df["Stock"].fillna(0)
+    if "Benchmark Price" in df.columns:
+        median_benchmark = df["Benchmark Price"].median()
+        df["Benchmark Price"] = df["Benchmark Price"].fillna(median_benchmark)
+    if "Returns" in df.columns:
+        df["Returns"] = df["Returns"].fillna(0)
+
+    df.drop_duplicates(inplace=True)
+
+    if "Listing Link" in df.columns:
+        df = df[df["Listing Link"].astype(str).str.startswith(("http", "https"))]
+        df["FSN"] = df["Listing Link"].apply(extract_fsn)
+
+    if "Fulfillment Type" in df.columns:
+        df["Fulfillment Type"] = df["Fulfillment Type"].replace({
+            "Flipkart and Seller Only": "Flipkart & Seller Only"
+        })
+    if "LQS" in df.columns:
+        df["LQS"] = df["LQS"].str.capitalize()
+
+    return df
+
+def upload_to_postgres(df: pd.DataFrame):
+    """Upload the cleaned dataframe to PostgreSQL."""
+    df = df.applymap(lambda x: x.encode('utf-8', 'ignore').decode('utf-8') if isinstance(x, str) else x)
+    df.columns = [col.strip().replace(" ", "_").lower() for col in df.columns]
+    engine = create_engine(f"postgresql://{DB_USER}:{DB_PASS}@{DB_HOST}/{DB_NAME}")
+    df.to_sql(TABLE_NAME, engine, if_exists="append", index=False)
+    print(f"✅ Data appended to table '{TABLE_NAME}' in PostgreSQL.")
+
+def main():
+    parser = argparse.ArgumentParser(description="Clean Flipkart Excel data and upload to PostgreSQL")
+    parser.add_argument("excel_path", help="Path to the input Excel file")
+    parser.add_argument("--sheet", default="Recovered_Sheet1", help="Excel sheet name")
+    args = parser.parse_args()
+
+    df_raw = pd.read_excel(args.excel_path, sheet_name=args.sheet, engine="openpyxl")
+    df_cleaned = clean_data(df_raw)
+    df_cleaned['insertion_date'] = datetime.now().date()
+    upload_to_postgres(df_cleaned)
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pandas
+openpyxl
+SQLAlchemy
+psycopg2-binary


### PR DESCRIPTION
## Summary
- add a standard `.gitignore`
- organize ETL code under `flipkart_etl` package
- provide command line interface with environment based DB config
- document how to run the ETL
- list required Python packages
- add MIT license
- update repository README
- add package metadata

## Testing
- `python -m py_compile flipkart_etl/etl.py`


------
https://chatgpt.com/codex/tasks/task_e_6842b3250bfc832996935340b48226f3